### PR TITLE
[EXD-68] Fetch data for user/me endpoint to return roles in response

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -10,11 +10,14 @@ export class UserController {
 
   @Get('me')
   @UseGuards(AuthenticatedGuard)
-  public getUserMe(@Req() req: Request): UserMeDTO {
+  public async getUserMe(@Req() req: Request): Promise<UserMeDTO> {
     console.log('req', req.sessionStore);
+
+    const user = await this.userService.readById(req.user.toString());
+
     return {
-      uid: req.user.toString(),
-      email: '', //@TODO read from db
+      uid: user.id,
+      roles: user.roles,
     };
   }
 }

--- a/src/user/user.interface.ts
+++ b/src/user/user.interface.ts
@@ -1,10 +1,14 @@
 export interface UserMeDTO {
   uid: string;
-  email: string;
+  roles: UserRoleDTO[];
 }
 
 export interface User {
   id: string;
   email: string;
   displayName: string;
+}
+
+export interface UserRoleDTO {
+  name: string;
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,30 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { UserEntity } from './entity/user.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Uuid } from '../common/common.interface';
 
 @Injectable()
-export class UserService {}
+export class UserService {
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly userRepository: Repository<UserEntity>,
+  ) {}
+
+  public async readById(id: Uuid): Promise<UserEntity> {
+    const user = await this.userRepository.findOne({
+      where: {
+        id,
+      },
+      relations: {
+        roles: true,
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException(`User with id ${id} not found`);
+    }
+
+    return user;
+  }
+}


### PR DESCRIPTION
Expand user/me endpoint to include currently assigned roles.
Example response data:
```json
{
  "uid": "cd7b3a2b-f399-4ac7-aa6c-7ab0ada6eef6",
  "roles": [
    {
      "name": "USER"
    }
  ]
}
```